### PR TITLE
Fix #12270: add TNR for searching on persistent identifiers

### DIFF
--- a/data/SIP_OK/ZIP/OK_images_2Binary-1Physical_withIdArk_2.2.zip
+++ b/data/SIP_OK/ZIP/OK_images_2Binary-1Physical_withIdArk_2.2.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e582e9e01221f5cbd3fe014cc82476b65c0f368f3718674a26076a6519b88d8
+oid sha256:5d96842bb664b6fe7174927d0000ec2e53d4baccfab689a52b9cf105072879f8
 size 79442

--- a/persistent-identifier.feature
+++ b/persistent-identifier.feature
@@ -4,7 +4,7 @@
 Fonctionnalité: recherche sur les identifiants ARK
 
   Contexte: Avant de lancer cette suite de test, je présuppose que le contrat de gestion avec ID pérenne est chargé et déclaré dans un contrat d'entrée.
-    Etant donné les tests effectués sur le tenant 0
+    Etant donné les tests effectués sur le tenant 1
     Et un contract nommé data/contracts/management/OK_contract_management_IdentificationPolicy.json
     Et j'importe ce contrat sans échec de type MANAGEMENT_CONTRACTS
     Et un contract nommé data/contracts/entree/referential_contracts_ark.json


### PR DESCRIPTION
Fix the TNR that was not working due to bad tenant and manifest.